### PR TITLE
Time filter

### DIFF
--- a/source/Utils/include/FilterTimeHits.h
+++ b/source/Utils/include/FilterTimeHits.h
@@ -6,6 +6,9 @@
 #include <string>
 #include <vector>
 
+#include "DDRec/Surface.h"
+#include "DDRec/SurfaceManager.h"
+
 #include <TH1F.h>
 #include <TMath.h>
 
@@ -23,8 +26,8 @@ using namespace marlin;
  *  @parameter TrackerSimHitOutputCollections name of the tracker simhit output collections
  *  @parameter TrackerHitOutputRelations name of the tracker hit relation output collections
  *  @parameter TargetBeta target beta=v/c for hit time of flight correction
- *  @parameter TimeLowerLimit lower limit on the corrected hit time in ps
- *  @parameter TimeUpperLimit upper limit on the corrected hit time in ps
+ *  @parameter TimeLowerLimit lower limit on the corrected hit time in ns
+ *  @parameter TimeUpperLimit upper limit on the corrected hit time in ns
  *  @parameter FillHistograms flag to fill the diagnostic histograms
  *
  * @author F. Meloni, DESY

--- a/source/Utils/include/FilterTimeHits.h
+++ b/source/Utils/include/FilterTimeHits.h
@@ -1,0 +1,76 @@
+#ifndef FilterTimeHits_h
+#define FilterTimeHits_h 1
+
+#include "marlin/Processor.h"
+#include "lcio.h"
+#include <string>
+#include <vector>
+
+#include <TH1F.h>
+#include <TMath.h>
+
+using namespace lcio;
+using namespace marlin;
+
+/** Utility processor that selects and saves the tracker hits with a polar angle
+ *  within a given range (defined by the lower and upper limit), along with
+ *  the corresponding sim hits and the reco-sim relations.
+ *
+ *  @parameter TrackerHitInputCollections name of the tracker hit input collections
+ *  @parameter TrackerSimHitInputCollections name of the tracker simhit input collections
+ *  @parameter TrackerHitInputRelations name of the tracker hit relation input collections
+ *  @parameter TrackerHitOutputCollections name of the tracker hit output collections
+ *  @parameter TrackerSimHitOutputCollections name of the tracker simhit output collections
+ *  @parameter TrackerHitOutputRelations name of the tracker hit relation output collections
+ *  @parameter TargetBeta target beta=v/c for hit time of flight correction
+ *  @parameter TimeLowerLimit lower limit on the corrected hit time in ps
+ *  @parameter TimeUpperLimit upper limit on the corrected hit time in ps
+ *  @parameter FillHistograms flag to fill the diagnostic histograms
+ *
+ * @author F. Meloni, DESY
+ * @date  8 June 2021
+ * @version $Id: FilterTimeHits.h,v 0.1 2021-06-08 08:58:00 fmeloni Exp $
+ */
+
+class FilterTimeHits : public Processor
+{
+
+public:
+    virtual Processor *newProcessor() { return new FilterTimeHits; }
+
+    FilterTimeHits();
+
+    virtual void init();
+
+    virtual void processRunHeader(LCRunHeader *run);
+
+    virtual void processEvent(LCEvent *evt);
+
+    virtual void check(LCEvent *evt);
+
+    virtual void end();
+
+protected:
+    // --- Input/output collection names:
+    std::vector<std::string> m_inputTrackerHitsCollNames{};
+    std::vector<std::string> m_inputTrackerSimHitsCollNames{};
+    std::vector<std::string> m_inputTrackerHitRelNames{};
+    std::vector<std::string> m_outputTrackerHitsCollNames{};
+    std::vector<std::string> m_outputTrackerSimHitsCollNames{};
+    std::vector<std::string> m_outputTrackerHitRelNames{};
+
+    // --- Processor parameters:
+    bool m_fillHistos{};
+    double m_beta{};
+    double m_time_min{};
+    double m_time_max{};
+
+    // --- Diagnostic histograms:
+    TH1F *m_corrected_time = nullptr;
+
+    // --- Run and event counters:
+    int _nRun{};
+    int _nEvt{};
+};
+
+#endif

--- a/source/Utils/src/FilterTimeHits.cc
+++ b/source/Utils/src/FilterTimeHits.cc
@@ -1,0 +1,333 @@
+#include "FilterTimeHits.h"
+#include <iostream>
+#include <cmath>
+#include <set>
+
+#include <IMPL/LCCollectionVec.h>
+#include <IMPL/TrackerHitPlaneImpl.h>
+#include <IMPL/SimTrackerHitImpl.h>
+#include <IMPL/LCRelationImpl.h>
+#include <IMPL/LCFlagImpl.h>
+
+#include <marlin/AIDAProcessor.h>
+
+using namespace lcio;
+using namespace marlin;
+
+FilterTimeHits aFilterTimeHits;
+
+FilterTimeHits::FilterTimeHits() : Processor("FilterTimeHits")
+{
+
+    // --- Processor description:
+
+    _description = "FilterTimeHits selects tracker hits based on their time corrected for the time of flight";
+
+    // --- Processor parameters:
+
+    registerProcessorParameter("TrackerHitInputCollections",
+                               "Name of the tracker hit input collections",
+                               m_inputTrackerHitsCollNames,
+                               {});
+
+    registerProcessorParameter("TrackerSimHitInputCollections",
+                               "Name of the tracker simhit input collections",
+                               m_inputTrackerSimHitsCollNames,
+                               {});
+
+    registerProcessorParameter("TrackerHitInputRelations",
+                               "Name of the tracker hit relation collections",
+                               m_inputTrackerHitRelNames,
+                               {});
+
+    registerProcessorParameter("TrackerHitOutputCollections",
+                               "Name of the tracker hit output collections",
+                               m_outputTrackerHitsCollNames,
+                               {});
+
+    registerProcessorParameter("TrackerSimHitOutputCollections",
+                               "Name of the tracker simhit output collections",
+                               m_outputTrackerSimHitsCollNames,
+                               {});
+
+    registerProcessorParameter("TrackerHitOutputRelations",
+                               "Name of the tracker hit relation collections",
+                               m_outputTrackerHitRelNames,
+                               {});
+
+    registerProcessorParameter("TargetBeta",
+                               "Target beta=v/c for hit time of flight correction",
+                               m_beta,
+                               double(1.0));
+
+    registerProcessorParameter("TimeLowerLimit",
+                               "Lower limit on the corrected hit time in ps",
+                               m_time_min,
+                               double(-90.0));
+
+    registerProcessorParameter("TimeUpperLimit",
+                               "Upper limit on the corrected hit time in ps",
+                               m_time_max,
+                               double(90.0));
+
+    registerProcessorParameter("FillHistograms",
+                               "Flag to fill the diagnostic histograms",
+                               m_fillHistos,
+                               false);
+}
+
+void FilterTimeHits::init()
+{
+
+    streamlog_out(DEBUG) << "   init called  " << std::endl;
+
+    // --- Print the processor parameters:
+
+    printParameters();
+
+    // --- Initialize the run and event counters:
+
+    _nRun = 0;
+    _nEvt = 0;
+
+    // --- Initialize the AIDAProcessor and book the diagnostic histograms:
+
+    AIDAProcessor::histogramFactory(this);
+
+    m_corrected_time = new TH1F("m_corrected_time", "Corrected time of the hit [ps]", 1000, -250., 250.);
+}
+
+void FilterTimeHits::processRunHeader(LCRunHeader *run)
+{
+
+    _nRun++;
+}
+
+void FilterTimeHits::processEvent(LCEvent *evt)
+{
+
+    // --- Check whether the number of input and output collections match
+
+    if (m_inputTrackerHitsCollNames.size() != m_inputTrackerSimHitsCollNames.size() ||
+        m_inputTrackerHitsCollNames.size() != m_inputTrackerHitRelNames.size())
+    {
+
+        std::stringstream err_msg;
+        err_msg << "Mismatch between the reco and sim hits input collections"
+                << std::endl;
+
+        throw EVENT::Exception(err_msg.str());
+    }
+
+    if (m_outputTrackerHitsCollNames.size() != m_outputTrackerSimHitsCollNames.size() ||
+        m_outputTrackerHitsCollNames.size() != m_outputTrackerHitRelNames.size())
+    {
+
+        std::stringstream err_msg;
+        err_msg << "Mismatch between the reco and sim hits output collections"
+                << std::endl;
+
+        throw EVENT::Exception(err_msg.str());
+    }
+
+    // --- Get the input hit collections and create the corresponding output collections:
+
+    const unsigned int nTrackerHitCol = m_inputTrackerHitsCollNames.size();
+    std::vector<LCCollection *> inputHitColls(nTrackerHitCol);
+    std::vector<LCCollection *> inputSimHitColls(nTrackerHitCol);
+    std::vector<LCCollection *> inputHitRels(nTrackerHitCol);
+
+    std::vector<LCCollectionVec *> outputTrackerHitColls(nTrackerHitCol);
+    std::vector<LCCollectionVec *> outputTrackerSimHitColls(nTrackerHitCol);
+    std::vector<LCCollectionVec *> outputTrackerHitRels(nTrackerHitCol);
+
+    for (unsigned int icol = 0; icol < nTrackerHitCol; ++icol)
+    {
+
+        // get the reco hits
+        try
+        {
+            inputHitColls[icol] = evt->getCollection(m_inputTrackerHitsCollNames[icol]);
+        }
+        catch (lcio::DataNotAvailableException &e)
+        {
+            streamlog_out(WARNING) << m_inputTrackerHitsCollNames[icol]
+                                   << " collection not available" << std::endl;
+            continue;
+        }
+
+        // get the sim hits
+        try
+        {
+            inputSimHitColls[icol] = evt->getCollection(m_inputTrackerSimHitsCollNames[icol]);
+        }
+        catch (lcio::DataNotAvailableException &e)
+        {
+            streamlog_out(WARNING) << m_inputTrackerSimHitsCollNames[icol]
+                                   << " collection not available" << std::endl;
+            continue;
+        }
+
+        // get the reco-sim relations
+        try
+        {
+            inputHitRels[icol] = evt->getCollection(m_inputTrackerHitRelNames[icol]);
+        }
+        catch (lcio::DataNotAvailableException &e)
+        {
+            streamlog_out(WARNING) << m_inputTrackerHitRelNames[icol]
+                                   << " collection not available" << std::endl;
+            continue;
+        }
+
+        // reco hit output collections
+        std::string encoderString = inputHitColls[icol]->getParameters().getStringVal("CellIDEncoding");
+        outputTrackerHitColls[icol] = new LCCollectionVec(inputHitColls[icol]->getTypeName());
+        outputTrackerHitColls[icol]->parameters().setValue("CellIDEncoding", encoderString);
+        LCFlagImpl lcFlag(inputHitColls[icol]->getFlag());
+        outputTrackerHitColls[icol]->setFlag(lcFlag.getFlag());
+
+        // sim hit output collections
+        outputTrackerSimHitColls[icol] = new LCCollectionVec(inputSimHitColls[icol]->getTypeName());
+        outputTrackerSimHitColls[icol]->parameters().setValue("CellIDEncoding", encoderString);
+        LCFlagImpl lcFlag_sim(inputSimHitColls[icol]->getFlag());
+        outputTrackerSimHitColls[icol]->setFlag(lcFlag_sim.getFlag());
+
+        // reco-sim relation output collections
+        outputTrackerHitRels[icol] = new LCCollectionVec(inputHitRels[icol]->getTypeName());
+        LCFlagImpl lcFlag_rel(inputHitRels[icol]->getFlag());
+        outputTrackerHitRels[icol]->setFlag(lcFlag_rel.getFlag());
+    }
+
+    // --- Loop over the tracker hits and select hits inside the chosen time window:
+
+    std::vector<std::set<int>> hits_to_save(nTrackerHitCol);
+
+    for (unsigned int icol = 0; icol < inputHitColls.size(); ++icol)
+    {
+
+        LCCollection *hit_col = inputHitColls[icol];
+        if (!hit_col)
+            continue;
+
+        for (int ihit = 0; ihit < hit_col->getNumberOfElements(); ++ihit)
+        {
+
+            TrackerHitPlane *hit = dynamic_cast<TrackerHitPlane *>(hit_col->getElementAt(ihit));
+
+            // Skipping the hit if its time is outside the acceptance time window
+            double hitT = hit->getTime();
+            double hitR = sqrt(hit->getPosition()[0] * hit->getPosition()[0] + hit->getPosition()[1] * hit->getPosition()[1] + hit->getPosition()[2] * hit->getPosition()[2]);
+
+            // Correcting for the propagation time
+            double dt = hitR / (TMath::C() * m_beta / 1e6);
+            hitT -= dt;
+            streamlog_out(DEBUG3) << "corrected hit at R: " << hitR << " mm by propagation time: " << dt << " ns to T: " << hitT << " ns" << std::endl;
+
+            //Apply time window selection (converting in ps)
+            if (hitT * 1e3 < m_time_min || hitT * 1e3 > m_time_max)
+            {
+                streamlog_out(DEBUG4) << "hit at T: " << hitT << " ns is rejected by timing cuts" << std::endl;
+                continue;
+            }
+
+            hits_to_save[icol].insert(ihit);
+
+            if (m_fillHistos)
+                m_corrected_time->Fill(hitT);
+
+        } // ihit loop
+
+    } // icol loop
+
+    // --- Add the filtered hits to the output collections:
+
+    for (unsigned int icol = 0; icol < inputHitColls.size(); ++icol)
+    {
+
+        for (auto &ihit : hits_to_save[icol])
+        {
+
+            TrackerHitPlane *hit = dynamic_cast<TrackerHitPlane *>(inputHitColls[icol]->getElementAt(ihit));
+            TrackerHitPlaneImpl *hit_new = new TrackerHitPlaneImpl();
+
+            hit_new->setCellID0(hit->getCellID0());
+            hit_new->setCellID1(hit->getCellID1());
+            hit_new->setType(hit->getType());
+            hit_new->setPosition(hit->getPosition());
+            hit_new->setU(hit->getU());
+            hit_new->setV(hit->getV());
+            hit_new->setdU(hit->getdU());
+            hit_new->setdV(hit->getdV());
+            hit_new->setEDep(hit->getEDep());
+            hit_new->setEDepError(hit->getEDepError());
+            hit_new->setTime(hit->getTime());
+            hit_new->setQuality(hit->getQuality());
+
+            outputTrackerHitColls[icol]->addElement(hit_new);
+
+            LCRelation *rel = dynamic_cast<LCRelation *>(inputHitRels[icol]->getElementAt(ihit));
+
+            SimTrackerHit *simhit = dynamic_cast<SimTrackerHit *>(rel->getTo());
+            SimTrackerHitImpl *simhit_new = new SimTrackerHitImpl();
+
+            simhit_new->setCellID0(simhit->getCellID0());
+            simhit_new->setCellID1(simhit->getCellID1());
+            simhit_new->setPosition(simhit->getPosition());
+            simhit_new->setEDep(simhit->getEDep());
+            simhit_new->setTime(simhit->getTime());
+            simhit_new->setMCParticle(simhit->getMCParticle());
+            simhit_new->setMomentum(simhit->getMomentum());
+            simhit_new->setPathLength(simhit->getPathLength());
+            simhit_new->setQuality(simhit->getQuality());
+            simhit_new->setOverlay(simhit->isOverlay());
+            simhit_new->setProducedBySecondary(simhit->isProducedBySecondary());
+
+            outputTrackerSimHitColls[icol]->addElement(simhit_new);
+
+            LCRelationImpl *rel_new = new LCRelationImpl();
+
+            rel_new->setFrom(hit_new);
+            rel_new->setTo(simhit_new);
+            rel_new->setWeight(rel->getWeight());
+
+            outputTrackerHitRels[icol]->addElement(rel_new);
+
+        } // ihit loop
+
+        streamlog_out(MESSAGE) << " " << hits_to_save[icol].size() << " hits added to the collections: "
+                               << m_outputTrackerHitsCollNames[icol] << ", "
+                               << m_outputTrackerSimHitsCollNames[icol] << ", "
+                               << m_outputTrackerHitRelNames[icol] << std::endl;
+
+        evt->addCollection(outputTrackerHitColls[icol], m_outputTrackerHitsCollNames[icol]);
+        evt->addCollection(outputTrackerSimHitColls[icol], m_outputTrackerSimHitsCollNames[icol]);
+        evt->addCollection(outputTrackerHitRels[icol], m_outputTrackerHitRelNames[icol]);
+
+        streamlog_out(DEBUG5) << " output collection " << m_outputTrackerHitsCollNames[icol] << " of type "
+                              << outputTrackerHitColls[icol]->getTypeName() << " added to the event \n"
+                              << " output collection " << m_outputTrackerSimHitsCollNames[icol] << " of type "
+                              << outputTrackerSimHitColls[icol]->getTypeName() << " added to the event \n"
+                              << " output collection " << m_outputTrackerHitRelNames[icol] << " of type "
+                              << outputTrackerHitRels[icol]->getTypeName() << " added to the event  "
+                              << std::endl;
+
+    } // icol loop
+
+    streamlog_out(DEBUG) << "   processing event: " << evt->getEventNumber()
+                         << "   in run:  " << evt->getRunNumber() << std::endl;
+
+    _nEvt++;
+}
+
+void FilterTimeHits::check(LCEvent *evt)
+{
+}
+
+void FilterTimeHits::end()
+{
+
+    std::cout << "FilterTimeHits::end()  " << name()
+              << " processed " << _nEvt << " events in " << _nRun << " runs "
+              << std::endl;
+}


### PR DESCRIPTION
This PR adds the time filter standalone processor for the selection of hits in the tracker.

BEGINRELEASENOTES
- Added FilterTimeHits processor for standalone (i.e. outside of digitiser/smearing processor) filtering hits depending on their time corrected by the time of flight. Particle propagation at a speed<c is supported via the TargetBeta parameter.
ENDRELEASENOTES